### PR TITLE
test: fix the tests for duckdb 0.10

### DIFF
--- a/tests/testthat/test-addCategories.R
+++ b/tests/testthat/test-addCategories.R
@@ -17,17 +17,19 @@ test_that("addCategories, functionality", {
     ) %>%
     dplyr::arrange(subject_id, cohort_start_date)
 
-  expect_true(all(agegroup %>%
+  expect_equal(agegroup %>%
     dplyr::select(age_group) %>%
-    dplyr::pull() ==
-    c("0 to 40", "41 to 120", "41 to 120", "0 to 40")))
+    dplyr::arrange(age_group) %>%
+    dplyr::pull(),
+    c("0 to 40", "0 to 40", "41 to 120", "41 to 120"))
 
-  expect_true(all(agegroupOverlap %>%
+  expect_equal(agegroupOverlap %>%
     dplyr::select(age_group) %>%
-    dplyr::pull() ==
+    dplyr::arrange(age_group) %>%
+    dplyr::pull(),
     c(
-      "0 to 55",  "50 to 120", "0 to 55 and 50 to 120", "0 to 55"
-    )))
+      "0 to 55", "0 to 55", "50 to 120", "0 to 55 and 50 to 120"
+    ))
 })
 
 test_that("addCategories with infinity", {


### PR DESCRIPTION
The new version of duckdb seems to have changed the order of the rows and the test fails (See https://github.com/duckdb/duckdb-r/pull/49#issuecomment-1960693033).
I think we must be sure to reorder them here to guarantee the order.