### PR TITLE
Issue 460

### DIFF
--- a/R/addDemographics.R
+++ b/R/addDemographics.R
@@ -197,15 +197,24 @@ addDemographics <- function(x,
 
   # join if not the person table
   if (any(!c("person_id", "gender_concept_id") %in% colnames(x))) {
+
+    addCols <- colnames(personDetails)[
+      which(colnames(personDetails) != personVariable)]
+
+    if(any(addCols %in%
+       colnames(x))
+    ){
+      checkNewName(name = addCols, x = x)
+      x <- x %>%
+        dplyr::select(!dplyr::any_of(addCols))
+    }
+
     x <- x %>%
       dplyr::left_join(
         personDetails %>%
           dplyr::select(dplyr::any_of(c(
             personVariable,
-            "date_of_birth",
-            "gender_concept_id",
-            "observation_period_start_date",
-            "observation_period_end_date"
+            addCols
           ))),
         by = personVariable
       )

--- a/R/addDemographics.R
+++ b/R/addDemographics.R
@@ -221,6 +221,18 @@ addDemographics <- function(x,
   }
 
   if (priorObservation == TRUE || futureObservation == TRUE) {
+
+    addCols <- colnames(obsPeriodDetails)[
+      which(!colnames(obsPeriodDetails) %in% c(personVariable, indexDate))]
+
+    if(any(addCols %in%
+           colnames(x))
+    ){
+      checkNewName(name = addCols, x = x)
+      x <- x %>%
+        dplyr::select(!dplyr::any_of(addCols))
+    }
+
     x <- x %>%
       dplyr::left_join(obsPeriodDetails,
         by = c(personVariable, indexDate)

--- a/tests/testthat/test-addDemographics.R
+++ b/tests/testthat/test-addDemographics.R
@@ -1223,3 +1223,14 @@ test_that("missing levels", {
     dplyr::collect()
   expect_true(all(!is.na(result$sex)))
 })
+
+test_that("age after dob", {
+  cdm <- mockPatientProfiles(connectionDetails)
+
+  cdm$cohort1 <- cdm$cohort1 %>%
+    PatientProfiles::addDateOfBirth()
+  expect_warning(cdm$cohort1 <- cdm$cohort1 %>%
+    PatientProfiles::addDemographics())
+  expect_true("date_of_birth" %in%   colnames(cdm$cohort1))
+
+})

--- a/tests/testthat/test-addDemographics.R
+++ b/tests/testthat/test-addDemographics.R
@@ -1224,7 +1224,7 @@ test_that("missing levels", {
   expect_true(all(!is.na(result$sex)))
 })
 
-test_that("age after dob", {
+test_that("overwriting obs period variables", {
   cdm <- mockPatientProfiles(connectionDetails)
 
   cdm$cohort1 <- cdm$cohort1 %>%
@@ -1232,5 +1232,26 @@ test_that("age after dob", {
   expect_warning(cdm$cohort1 <- cdm$cohort1 %>%
     PatientProfiles::addDemographics())
   expect_true("date_of_birth" %in%   colnames(cdm$cohort1))
+
+  cdm <- mockPatientProfiles(connectionDetails)
+  cdm$cohort1 <- cdm$cohort1 %>%
+    dplyr::mutate(observation_period_start_date = "a")
+  expect_warning(cdm$cohort1 %>%
+    PatientProfiles::addPriorObservation())
+  expect_warning(cdm$cohort1 %>%
+                   PatientProfiles::addFutureObservation())
+  expect_warning(cdm$cohort1 %>%
+                   PatientProfiles::addInObservation())
+
+  cdm <- mockPatientProfiles(connectionDetails)
+  cdm$cohort1 <- cdm$cohort1 %>%
+    dplyr::mutate(observation_period_start_date = "a",
+                  observation_period_end_date = "b")
+  expect_warning(cdm$cohort1 %>%
+                   PatientProfiles::addPriorObservation())
+  expect_warning(cdm$cohort1 %>%
+                   PatientProfiles::addFutureObservation())
+  expect_warning(cdm$cohort1 %>%
+    PatientProfiles::addInObservation())
 
 })


### PR DESCRIPTION
#460 

Error occurs when columns exist in the index cohort from the observation period that we want to recalculate when adding age, future observation, etc. I've overwritten these if they exist and added a warning.