### PR TITLE
add internal compute to addInObservation

### DIFF
--- a/R/addDemographics.R
+++ b/R/addDemographics.R
@@ -316,14 +316,21 @@ addInObservation <- function(x,
                              nameStyle = "in_observation",
                              name = NULL) {
   name <- validateName(name)
-  x |>
+
+  cdm <- omopgenerics::cdmReference(x)
+  tmpName <- omopgenerics::uniqueTableName()
+
+  x <- x |>
     .addInObservationQuery(
       indexDate = indexDate,
       window = window,
       completeInterval = completeInterval,
-      nameStyle = nameStyle
+      nameStyle = nameStyle,
+      tmpName = tmpName
     ) |>
     computeTable(name = name)
+
+  CDMConnector::dropTable(cdm = cdm, name = tmpName)
 }
 
 #' Compute the sex of the individuals

--- a/R/addDemographics.R
+++ b/R/addDemographics.R
@@ -330,7 +330,9 @@ addInObservation <- function(x,
     ) |>
     computeTable(name = name)
 
-  CDMConnector::dropTable(cdm = cdm, name = tmpName)
+  omopgenerics::dropTable(cdm = cdm, name = tmpName)
+
+  x
 }
 
 #' Compute the sex of the individuals

--- a/R/addDemographicsQuery.R
+++ b/R/addDemographicsQuery.R
@@ -683,6 +683,7 @@ addInObservationQuery <- function(x,
                                   window = c(0, 0),
                                   completeInterval = FALSE,
                                   nameStyle = "in_observation") {
+
   x |>
     .addInObservationQuery(
       indexDate = indexDate,
@@ -697,6 +698,7 @@ addInObservationQuery <- function(x,
                                    window = c(0, 0),
                                    completeInterval = FALSE,
                                    nameStyle = "in_observation",
+                                   tmpName = NULL,
                                    call = parent.frame()) {
   x <- validateX(x, call = call)
   indexDate <- validateIndexDate(indexDate, null = FALSE, x = x, call = call)
@@ -740,6 +742,9 @@ addInObservationQuery <- function(x,
       !!startDif := !!CDMConnector::datediff(indexDate, start),
       !!endDif := !!CDMConnector::datediff(indexDate, end)
     )
+  if(!is.null(tmpName)){
+    xnew <- xnew |> dplyr::compute(name = tmpName, temporary = FALSE)
+  }
 
   qR <- NULL
   for (k in seq_along(window)) {
@@ -779,7 +784,7 @@ addInObservationQuery <- function(x,
         }
       }
     }
-    nQ <- paste0("as.integer(", nQ, ")") |>
+    nQ <- paste0(nQ) |>
       glue::glue() |>
       rlang::parse_exprs() |>
       rlang::set_names(nam)
@@ -792,7 +797,7 @@ addInObservationQuery <- function(x,
       by = c(personVariable, indexDate)
     ) |>
     dplyr::mutate(dplyr::across(
-      dplyr::all_of(newColumns), ~ as.integer(dplyr::if_else(is.na(.x), 0L, .x))
+      dplyr::all_of(newColumns), ~ dplyr::coalesce(as.integer(.x), 0L)
     ))
 
   return(x)

--- a/tests/testthat/test-addDemographics.R
+++ b/tests/testthat/test-addDemographics.R
@@ -1320,10 +1320,16 @@ test_that("query gives same result as main function", {
   # we should get the same results if compute was internal or not
   result_1 <- cdm$cohort1 %>%
     PatientProfiles::addDemographics() %>%
-    dplyr::collect()
+    dplyr::collect()|>
+    dplyr::arrange(cohort_definition_id,
+                   subject_id,
+                   cohort_start_date)
   result_2 <- cdm$cohort1 %>%
     addDemographicsQuery() |>
-    dplyr::collect()
+    dplyr::collect()|>
+    dplyr::arrange(cohort_definition_id,
+                   subject_id,
+                   cohort_start_date)
   expect_equal(result_1, result_2)
 
   # check no tables are created along the way with query

--- a/tests/testthat/test-addDemographics.R
+++ b/tests/testthat/test-addDemographics.R
@@ -1384,8 +1384,14 @@ test_that("test query functions", {
   )
 
   for (k in seq_along(fun1)) {
-    x <- do.call(fun1[[k]], list(cdm$cohort1)) |> dplyr::collect()
-    y <- do.call(fun2[[k]], list(cdm$cohort1)) |> dplyr::collect()
+    x <- do.call(fun1[[k]], list(cdm$cohort1)) |> dplyr::collect() |>
+      dplyr::arrange(cohort_definition_id,
+                     subject_id,
+                     cohort_start_date)
+    y <- do.call(fun2[[k]], list(cdm$cohort1)) |> dplyr::collect() |>
+      dplyr::arrange(cohort_definition_id,
+                     subject_id,
+                     cohort_start_date)
     expect_identical(x, y)
   }
 

--- a/tests/testthat/test-addInObservation.R
+++ b/tests/testthat/test-addInObservation.R
@@ -172,10 +172,16 @@ test_that("query gives same result as main function", {
   # we should get the same results if compute was internal or not
   result_1 <- cdm$cohort1 %>%
     addInObservation() %>%
-    dplyr::collect()
+    dplyr::collect() |>
+    dplyr::arrange(cohort_definition_id,
+                   subject_id,
+                   cohort_start_date)
   result_2 <- cdm$cohort1 %>%
     addInObservationQuery() |>
-    dplyr::collect()
+    dplyr::collect() |>
+    dplyr::arrange(cohort_definition_id,
+                   subject_id,
+                   cohort_start_date)
   expect_equal(result_1, result_2)
 
   # check no tables are created along the way with query


### PR DESCRIPTION
for #712 Intermediate compute will only be used if using addInObservation, addInObservationQuery would still provide the full uncomputed query

Still to do: 
- run current main a few times on full database to benchmark current performance
- run this pr a few times on full database to see if there is an improvement
- see if adding another compute here https://github.com/darwin-eu-dev/PatientProfiles/blob/e666244f2725fb4231279cd6aea6b380be3acf93/R/addDemographicsQuery.R#L741 would help (materialising result before date comparisons)